### PR TITLE
#3 Fix login button on creator's page, redirect to login if not logged in

### DIFF
--- a/client/src/components/community/header.jsx
+++ b/client/src/components/community/header.jsx
@@ -78,8 +78,13 @@ const Header = ({ community }) => {
                 pr={6}
                 pl={6}
                 onClick={() => {
-                  onJoinLeaveCommunity(community._id, user);
-                  navigate(0);
+                  if(user){                                                // If user logged in
+                    onJoinLeaveCommunity(community._id, user);
+                    navigate(0);
+                  }
+                  else{                                                    // If user not logged in
+                    navigate('/login');
+                  }
                 }}
               >
                 {community && isUserJoinCommunity() ? "Joined" : "Join"}


### PR DESCRIPTION
Fix login button on creator's page, redirect to login if not logged in

Resolved an issue where clicking the join button on a creator's main
page without logging in caused a page refresh. Now the button redirects
to the login page for non-logged-in users.

Fixes #3 